### PR TITLE
Don't depend on pybuild in the clean step

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,5 +7,8 @@ override_dh_install:
 	dh_install --fail-missing
 	cp -a $(CURDIR)/data/bash-completion/nymea-cli $(CURDIR)/debian/nymea-cli/usr/share/bash-completion/completions/ || true
 
+override_dh_auto_clean:
+	dh $@
+
 %:
 	dh $@ --with python2 --buildsystem=pybuild


### PR DESCRIPTION
As the clean target is executed *before* installing the build depends
we have those options:

* "pollute" our builders with pybuild being preinstalled
* not executing the clean target in sbuild (sbuild builds would be clean by definition anyways)
* not rely on dependencies in the clean step

Decided to go for option 3